### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = ""

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@
   - 2 players.
   - Choose a column 1 - 7 to place your piece.
   - 4 in a row wins.
+
+  [![Run on Repl.it](https://repl.it/badge/github/bendee48/connect_four)](https://repl.it/github/bendee48/connect_four)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@bendee48/connectfour).